### PR TITLE
Implement task-based decision control

### DIFF
--- a/Core/Hydronom.Core.csproj
+++ b/Core/Hydronom.Core.csproj
@@ -8,7 +8,8 @@
 
   <ItemGroup>
       <Compile Include="Modules/TaskModule/TaskManager.cs" />
-     <Compile Include="Modules/DecisionModule/DecisionManager.cs" />
+      <Compile Include="Modules/TaskModule/Task.cs" />
+      <Compile Include="Modules/DecisionModule/DecisionManager.cs" />
         <Compile Include="Modules/ControlModule/ControlManager.cs" />
       <Compile Include="Modules/AnalysisModule/AnalysisManager.cs" />
         <Compile Include="Modules/FeedbackModule/FeedbackManager.cs" />

--- a/Core/Modules/DecisionModule/DecisionManager.cs
+++ b/Core/Modules/DecisionModule/DecisionManager.cs
@@ -1,1 +1,22 @@
-namespace Hydronom.Core.Modules.DecisionModule { public class DecisionManager { public DecisionManager() { } public void Evaluate() { System.Console.WriteLine("🤖 Decision evaluated."); } } }
+using System;
+using Hydronom.Core.Modules.TaskModule;
+
+namespace Hydronom.Core.Modules.DecisionModule
+{
+    public class DecisionManager
+    {
+        public DecisionManager() { }
+
+        public void Evaluate(Task task)
+        {
+            string mode = task.Type switch
+            {
+                TaskType.AreaScan => "AutonomousControl",
+                TaskType.Docking => "ManualControl",
+                _ => "UnknownControl"
+            };
+
+            Console.WriteLine($"🤖 Decision evaluated. Activating {mode}.");
+        }
+    }
+}

--- a/Core/Modules/TaskModule/Task.cs
+++ b/Core/Modules/TaskModule/Task.cs
@@ -1,0 +1,19 @@
+namespace Hydronom.Core.Modules.TaskModule
+{
+    public enum TaskType
+    {
+        AreaScan,
+        Docking,
+        Unknown
+    }
+
+    public class Task
+    {
+        public TaskType Type { get; }
+
+        public Task(TaskType type)
+        {
+            Type = type;
+        }
+    }
+}

--- a/Core/Program.cs
+++ b/Core/Program.cs
@@ -24,7 +24,11 @@ namespace Hydronom.Core
             // Basit test çalıştırmaları (ileride görev döngüsüne dönüştürülecek)
             taskManager.AssignTask();
             analysisManager.Analyze();
-            decisionManager.Evaluate();
+
+            // Örnek bir görev üzerinde karar ver
+            var task = new Task(TaskType.AreaScan);
+            decisionManager.Evaluate(task);
+
             controlManager.MoveForward();
             feedbackManager.Log();
 


### PR DESCRIPTION
## Summary
- add a `Task` model with `TaskType` enum
- choose control mode in `DecisionManager.Evaluate` based on the task
- use the new evaluation flow from `Program.Main`
- register the new file in project file

## Testing
- `dotnet build Core/Hydronom.Core.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b549b954833393aa89202f8b2caf